### PR TITLE
Made switch statments exhaustive, updated deployment target

### DIFF
--- a/Sources/ToastView.swift
+++ b/Sources/ToastView.swift
@@ -52,6 +52,7 @@ open class ToastView: UIView {
     case .pad: return 60
     case .tv: return 90
     case .carPlay: return 30
+    case .mac: return 60
     // default values
     case .unspecified: fallthrough
     @unknown default: return 30
@@ -66,6 +67,7 @@ open class ToastView: UIView {
     case .pad: return 40
     case .tv: return 60
     case .carPlay: return 20
+    case .mac: return 40
     // default values
     case .unspecified: fallthrough
     @unknown default: return 20
@@ -132,6 +134,7 @@ open class ToastView: UIView {
       case .pad: return .systemFont(ofSize: 16)
       case .tv: return .systemFont(ofSize: 20)
       case .carPlay: return .systemFont(ofSize: 12)
+      case .mac: return .systemFont(ofSize: 16)
       // default values
       case .unspecified: fallthrough
       @unknown default: return .systemFont(ofSize: 12)

--- a/Toaster.podspec
+++ b/Toaster.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.author       = { 'devxoul' => 'devxoul@gmail.com' }
   s.source       = { :git => 'https://github.com/devxoul/Toaster.git',
                      :tag => "#{s.version}" }
-  s.platform     = :ios, '8.0'
+  s.platform     = :ios, '9.0'
   s.source_files = 'Sources/*.{swift,h}'
   s.frameworks   = 'UIKit', 'Foundation', 'QuartzCore'
   s.swift_version = '5.0'

--- a/Toaster.xcodeproj/project.pbxproj
+++ b/Toaster.xcodeproj/project.pbxproj
@@ -605,7 +605,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = kr.xoul.Toaster;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -627,7 +627,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = kr.xoul.Toaster;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Bring exhaustive switch cases to Toaster lib. Is required to function on Xcode 12.

See this PR: https://github.com/devxoul/Toaster/pull/196 